### PR TITLE
Email Commands

### DIFF
--- a/components/email.php
+++ b/components/email.php
@@ -153,7 +153,7 @@ class BPCLI_Email extends BPCLI_Component {
 	 *     # Output the post ID for the 'activity-at-message' email type
 	 *     $ wp bp email get-post activity-at-message --fields=ID
 	 *
-	 * @subcommand get-post
+	 * @alias get-post
 	 */
 	public function get_post( $args, $assoc_args ) {
 		$email = bp_get_email( $args[0] );

--- a/components/email.php
+++ b/components/email.php
@@ -19,7 +19,7 @@ class BPCLI_Email extends BPCLI_Component {
 	 * --subject=<subject>
 	 * : Email subject line. Email tokens allowed. View https://codex.buddypress.org/emails/email-tokens/ for more info.
 	 *
-	 * --content=<content>
+	 * [--content=<content>]
 	 * : Email content. Email tokens allowed. View https://codex.buddypress.org/emails/email-tokens/ for more info.
 	 *
 	 * [--plain-text-content=<plain-text-content>]
@@ -197,6 +197,22 @@ class BPCLI_Email extends BPCLI_Component {
 		} else {
 			WP_CLI::error( $result[1] );
 		}
+	}
+
+	/**
+	 * Helper method to use the '--edit' flag.
+	 *
+	 * Copied from Post_Command::_edit().
+	 *
+	 * @param  string $content Post content
+	 * @param  string $title   Post title
+	 * @return mixed
+	 */
+	protected function _edit( $content, $title ) {
+		$content = apply_filters( 'the_editor_content', $content );
+		$output = \WP_CLI\Utils\launch_editor_for_input( $content, $title );
+		return ( is_string( $output ) ) ?
+			apply_filters( 'content_save_pre', $output ) : $output;
 	}
 }
 

--- a/components/email.php
+++ b/components/email.php
@@ -40,15 +40,6 @@ class BPCLI_Email extends BPCLI_Component {
 			switch_to_blog( bp_get_root_blog_id() );
 		}
 
-		// 'type' is required.
-		if ( empty( $assoc_args['type'] ) ) {
-			if ( true === $switched ) {
-				restore_current_blog();
-			}
-
-			WP_CLI::error( "The 'type' field must be filled in." );
-		}
-
 		$term = term_exists( $assoc_args['type'], bp_get_email_tax_type() );
 
 		// Term already exists so don't do anything.
@@ -58,15 +49,6 @@ class BPCLI_Email extends BPCLI_Component {
 			}
 
 			WP_CLI::error( "Email type '{$assoc_args['type']}' already exists." );
-		}
-
-		// 'subject' is required.
-		if ( empty( $assoc_args['subject'] ) ) {
-			if ( true === $switched ) {
-				restore_current_blog();
-			}
-
-			WP_CLI::error( "The 'subject' field must be filled in." );
 		}
 
 		if ( ! empty( $args[0] ) ) {
@@ -79,15 +61,6 @@ class BPCLI_Email extends BPCLI_Component {
 			} else {
 				$assoc_args['content'] = $input;
 			}
-		}
-
-		// 'content' is required.
-		if ( empty( $assoc_args['content'] ) ) {
-			if ( true === $switched ) {
-				restore_current_blog();
-			}
-
-			WP_CLI::error( "The 'content' field must be filled in." );
 		}
 
 		$id = $assoc_args['type'];

--- a/components/email.php
+++ b/components/email.php
@@ -10,24 +10,24 @@ class BPCLI_Email extends BPCLI_Component {
 	 *
 	 * ## OPTIONS
 	 *
-	 * [--type]
-	 * : Required. Email type for the email (should be unique identifier, sanitized like a post slug).
+	 * --type=<type>
+	 * : Email type for the email (should be unique identifier, sanitized like a post slug).
 	 *
-	 * [--type_description]
+	 * [--type-description=<type-description>]
 	 * : Email type description.
 	 *
-	 * [--subject]
-	 * : Required. Email subject line. Email tokens allowed. View https://codex.buddypress.org/emails/email-tokens/ for more info.
+	 * --subject=<subject>
+	 * : Email subject line. Email tokens allowed. View https://codex.buddypress.org/emails/email-tokens/ for more info.
 	 *
-	 * [--content]
-	 * : Required. Email content. Email tokens allowed. View https://codex.buddypress.org/emails/email-tokens/ for more info.
+	 * --content=<content>
+	 * : Email content. Email tokens allowed. View https://codex.buddypress.org/emails/email-tokens/ for more info.
 	 *
-	 * [--plain_text_content]
+	 * [--plain-text-content=<plain-text-content>]
 	 * : Plain-text email content. Email tokens allowed. View https://codex.buddypress.org/emails/email-tokens/ for more info.
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     $ wp bp email create --type=new-event --type_description="Send an email when a new event is created" --subject="[{{{site.name}}}] A new event was created" --content="<a href='{{{some.custom-token-url}}}'></a>A new event</a> was created" --plain_text_content="A new event was created"
+	 *     $ wp bp email create --type=new-event --type-description="Send an email when a new event is created" --subject="[{{{site.name}}}] A new event was created" --content="<a href='{{{some.custom-token-url}}}'></a>A new event</a> was created" --plain-text-content="A new event was created"
 	 *     Success: Email post created for type "new-event".
 	 *
 	 * @alias add
@@ -104,7 +104,7 @@ class BPCLI_Email extends BPCLI_Component {
 		$email = array(
 			'post_title'   => $assoc_args['subject'],
 			'post_content' => $assoc_args['content'],
-			'post_excerpt' => ! empty( $assoc_args['plaintext_content'] ) ? $assoc_args['plaintext_content'] :'',
+			'post_excerpt' => ! empty( $assoc_args['plain-text-content'] ) ? $assoc_args['plain-text-content'] :'',
 		);
 
 		// Email post content.
@@ -115,10 +115,10 @@ class BPCLI_Email extends BPCLI_Component {
 			$tt_ids = wp_set_object_terms( $post_id, $id, bp_get_email_tax_type() );
 
 			// Situation description.
-			if ( ! is_wp_error( $tt_ids ) && ! empty( $assoc_args['type_description'] ) ) {
+			if ( ! is_wp_error( $tt_ids ) && ! empty( $assoc_args['type-description'] ) ) {
 				$term = get_term_by( 'term_taxonomy_id', (int) $tt_ids[0], bp_get_email_tax_type() );
 				wp_update_term( (int) $term->term_id, bp_get_email_tax_type(), array(
-					'description' => $assoc_args['type_description'],
+					'description' => $assoc_args['type-description'],
 				) );
 			}
 

--- a/components/email.php
+++ b/components/email.php
@@ -160,7 +160,6 @@ class BPCLI_Email extends BPCLI_Component {
 
 		if ( is_wp_error( $email ) ) {
 			WP_CLI::error( "Email post for type '{$args[0]}' does not exist." );
-			return;
 		}
 
 		$post_arr = get_object_vars( $email->get_post_object() );

--- a/components/email.php
+++ b/components/email.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * Manage BuddyPress Email Post Types.
+ *
+ * @since 1.6.0
+ */
+class BPCLI_Email extends BPCLI_Component {
+	/**
+	 * Create a new email post connected to an email type.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--type]
+	 * : Required. Email type for the email (should be unique identifier, sanitized like a post slug).
+	 *
+	 * [--type_description]
+	 * : Email type description.
+	 *
+	 * [--subject]
+	 * : Required. Email subject line. Email tokens allowed. View https://codex.buddypress.org/emails/email-tokens/ for more info.
+	 *
+	 * [--content]
+	 * : Required. Email content. Email tokens allowed. View https://codex.buddypress.org/emails/email-tokens/ for more info.
+	 *
+	 * [--plain_text_content]
+	 * : Plain-text email content. Email tokens allowed. View https://codex.buddypress.org/emails/email-tokens/ for more info.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp bp email create --type=new-event --type_description="Send an email when a new event is created" --subject="[{{{site.name}}}] A new event was created" --content="<a href='{{{some.custom-token-url}}}'></a>A new event</a> was created" --plain_text_content="A new event was created"
+	 *     Success: Email post created for type "new-event".
+	 *
+	 * @alias add
+	 */
+	public function create( $args, $assoc_args ) {
+		$switched = false;
+
+		if ( false === bp_is_root_blog() ) {
+			$switched = true;
+			switch_to_blog( bp_get_root_blog_id() );
+		}
+
+		// 'type' is required.
+		if ( empty( $assoc_args['type'] ) ) {
+			if ( true === $switched ) {
+				restore_current_blog();
+			}
+
+			WP_CLI::error( "The 'type' field must be filled in." );
+			return;
+		}
+
+		$term = term_exists( $assoc_args['type'], bp_get_email_tax_type() );
+
+		// Term already exists so don't do anything.
+		if ( $term !== 0 && $term !== null ) {
+			if ( true === $switched ) {
+				restore_current_blog();
+			}
+
+			WP_CLI::error( "Email type '{$assoc_args['type']}' already exists." );
+			return;
+		}
+
+		// 'subject' is required.
+		if ( empty( $assoc_args['subject'] ) ) {
+			if ( true === $switched ) {
+				restore_current_blog();
+			}
+
+			WP_CLI::error( "The 'subject' field must be filled in." );
+			return;
+		}
+
+		if ( ! empty( $args[0] ) ) {
+			$assoc_args['content'] = $this->read_from_file_or_stdin( $args[0] );
+		}
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'edit' ) ) {
+			$input = \WP_CLI\Utils\get_flag_value( $assoc_args, 'content', '' );
+			if ( $output = $this->_edit( $input, 'WP-CLI: New BP Email Content' ) ) {
+				$assoc_args['content'] = $output;
+			} else {
+				$assoc_args['content'] = $input;
+			}
+		}
+
+		// 'content' is required.
+		if ( empty( $assoc_args['content'] ) ) {
+			if ( true === $switched ) {
+				restore_current_blog();
+			}
+
+			WP_CLI::error( "The 'content' field must be filled in." );
+			return;
+		}
+
+		$id = $assoc_args['type'];
+
+		$defaults = array(
+			'post_status' => 'publish',
+			'post_type'   => bp_get_email_post_type(),
+		);
+
+		$email = array(
+			'post_title'   => $assoc_args['subject'],
+			'post_content' => $assoc_args['content'],
+			'post_excerpt' => ! empty( $assoc_args['plaintext_content'] ) ? $assoc_args['plaintext_content'] :'',
+		);
+
+		// Email post content.
+		$post_id = wp_insert_post( bp_parse_args( $email, $defaults, 'install_email_' . $id ) );
+
+		// Save the situation.
+		if ( ! is_wp_error( $post_id ) ) {
+			$tt_ids = wp_set_object_terms( $post_id, $id, bp_get_email_tax_type() );
+
+			// Situation description.
+			if ( ! is_wp_error( $tt_ids ) && ! empty( $assoc_args['type_description'] ) ) {
+				$term = get_term_by( 'term_taxonomy_id', (int) $tt_ids[0], bp_get_email_tax_type() );
+				wp_update_term( (int) $term->term_id, bp_get_email_tax_type(), array(
+					'description' => $assoc_args['type_description'],
+				) );
+			}
+
+			WP_CLI::success( "Email post created for type '{$assoc_args['type']}'." );
+		} else {
+			WP_CLI::error( "There was a problem creating the email post for type '{$assoc_args['type']}'." );
+		}
+
+		if ( true === $switched ) {
+			restore_current_blog();
+		}
+	}
+
+	/**
+	 * Get details for a post connected to an email type.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <type>
+	 * : The email type to fetch the post details for.
+	 *
+	 * [--field=<field>]
+	 * : Instead of returning the whole post, returns the value of a single field.
+	 *
+	 * [--fields=<fields>]
+	 * : Limit the output to specific fields. Defaults to all fields.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLE
+	 *
+	 *     # Output the post ID for the 'activity-at-message' email type
+	 *     $ wp bp email get activity-at-message --fields=ID
+	 *
+	 * @subcommand get-post
+	 */
+	public function get_post( $args, $assoc_args ) {
+		$email = bp_get_email( $args[0] );
+
+		if ( is_wp_error( $email ) ) {
+			WP_CLI::error( "Email post for type '{$args[0]}' does not exist." );
+			return;
+		}
+
+		$post_arr = get_object_vars( $email->get_post_object() );
+		unset( $post_arr['filter'] );
+		if ( empty( $assoc_args['fields'] ) ) {
+			$assoc_args['fields'] = array_keys( $post_arr );
+		}
+
+		$formatter = $this->get_formatter( $assoc_args );
+		$formatter->display_item( $email->get_post_object() );
+	}
+
+	/**
+	 * Reinstall BuddyPress default emails.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--yes]
+	 * : Answer yes to the confirmation message.
+	 *
+	 * ## EXAMPLE
+	 *
+	 *     $ wp bp email reinstall --yes
+	 *     Success: Emails have been successfully reinstalled.
+	 */
+	public function reinstall( $args, $assoc_args ) {
+		WP_CLI::confirm( 'Are you sure you want to reinstall BuddyPress emails?', $assoc_args );
+
+		require_once buddypress()->plugin_dir . 'bp-core/admin/bp-core-admin-tools.php';
+
+		$result = bp_admin_reinstall_emails();
+
+		if ( 0 === $result[0] ) {
+			WP_CLI::success( $result[1] );
+		} else {
+			WP_CLI::error( $result[1] );
+		}
+	}
+}
+
+WP_CLI::add_command( 'bp email', 'BPCLI_EMail' );

--- a/components/email.php
+++ b/components/email.php
@@ -25,9 +25,27 @@ class BPCLI_Email extends BPCLI_Component {
 	 * [--plain-text-content=<plain-text-content>]
 	 * : Plain-text email content. Email tokens allowed. View https://codex.buddypress.org/emails/email-tokens/ for more info.
 	 *
+	 * [<file>]
+	 * : Read content from <file>. If this value is present, the
+	 *     `--content` argument will be ignored.
+	 *
+	 *   Passing `-` as the filename will cause post content to
+	 *   be read from STDIN.
+	 *
+	 * [--edit]
+	 * : Immediately open system's editor to write or edit email content.
+	 *
+	 *   If content is read from a file, from STDIN, or from the `--content`
+	 *   argument, that text will be loaded into the editor.
+	 *
 	 * ## EXAMPLES
 	 *
+	 *     # Create email post
 	 *     $ wp bp email create --type=new-event --type-description="Send an email when a new event is created" --subject="[{{{site.name}}}] A new event was created" --content="<a href='{{{some.custom-token-url}}}'></a>A new event</a> was created" --plain-text-content="A new event was created"
+	 *     Success: Email post created for type "new-event".
+	 *
+	 *     # Create email post with content from given file
+	 *     $ wp bp email create ./email-content.txt --type=new-event --type-description="Send an email when a new event is created" --subject="[{{{site.name}}}] A new event was created" --plain-text-content="A new event was created"
 	 *     Success: Email post created for type "new-event".
 	 *
 	 * @alias add

--- a/components/email.php
+++ b/components/email.php
@@ -133,7 +133,7 @@ class BPCLI_Email extends BPCLI_Component {
 	 * ## EXAMPLE
 	 *
 	 *     # Output the post ID for the 'activity-at-message' email type
-	 *     $ wp bp email get activity-at-message --fields=ID
+	 *     $ wp bp email get-post activity-at-message --fields=ID
 	 *
 	 * @subcommand get-post
 	 */

--- a/components/email.php
+++ b/components/email.php
@@ -95,7 +95,7 @@ class BPCLI_Email extends BPCLI_Component {
 		);
 
 		// Email post content.
-		$post_id = wp_insert_post( bp_parse_args( $email, $defaults, 'install_email_' . $id ) );
+		$post_id = wp_insert_post( bp_parse_args( $email, $defaults, 'install_email_' . $id ), true );
 
 		// Save the situation.
 		if ( ! is_wp_error( $post_id ) ) {
@@ -119,7 +119,7 @@ class BPCLI_Email extends BPCLI_Component {
 				restore_current_blog();
 			}
 
-			WP_CLI::error( "There was a problem creating the email post for type '{$assoc_args['type']}'." );
+			WP_CLI::error( "There was a problem creating the email post for type '{$assoc_args['type']}' - " . $post_id->get_error_message() );
 		}
 	}
 

--- a/components/email.php
+++ b/components/email.php
@@ -47,7 +47,6 @@ class BPCLI_Email extends BPCLI_Component {
 			}
 
 			WP_CLI::error( "The 'type' field must be filled in." );
-			return;
 		}
 
 		$term = term_exists( $assoc_args['type'], bp_get_email_tax_type() );
@@ -59,7 +58,6 @@ class BPCLI_Email extends BPCLI_Component {
 			}
 
 			WP_CLI::error( "Email type '{$assoc_args['type']}' already exists." );
-			return;
 		}
 
 		// 'subject' is required.
@@ -69,7 +67,6 @@ class BPCLI_Email extends BPCLI_Component {
 			}
 
 			WP_CLI::error( "The 'subject' field must be filled in." );
-			return;
 		}
 
 		if ( ! empty( $args[0] ) ) {
@@ -91,7 +88,6 @@ class BPCLI_Email extends BPCLI_Component {
 			}
 
 			WP_CLI::error( "The 'content' field must be filled in." );
-			return;
 		}
 
 		$id = $assoc_args['type'];
@@ -122,13 +118,17 @@ class BPCLI_Email extends BPCLI_Component {
 				) );
 			}
 
+			if ( true === $switched ) {
+				restore_current_blog();
+			}
+
 			WP_CLI::success( "Email post created for type '{$assoc_args['type']}'." );
 		} else {
-			WP_CLI::error( "There was a problem creating the email post for type '{$assoc_args['type']}'." );
-		}
+			if ( true === $switched ) {
+				restore_current_blog();
+			}
 
-		if ( true === $switched ) {
-			restore_current_blog();
+			WP_CLI::error( "There was a problem creating the email post for type '{$assoc_args['type']}'." );
 		}
 	}
 

--- a/components/email.php
+++ b/components/email.php
@@ -13,7 +13,7 @@ class BPCLI_Email extends BPCLI_Component {
 	 * --type=<type>
 	 * : Email type for the email (should be unique identifier, sanitized like a post slug).
 	 *
-	 * [--type-description=<type-description>]
+	 * --type-description=<type-description>
 	 * : Email type description.
 	 *
 	 * --subject=<subject>

--- a/components/tool.php
+++ b/components/tool.php
@@ -47,4 +47,8 @@ class BPCLI_Tool extends BPCLI_Component {
 	}
 }
 
-WP_CLI::add_command( 'bp tool', 'BPCLI_Tool' );
+WP_CLI::add_command( 'bp tool', 'BPCLI_Tool', array(
+	'before_invoke' => function() {
+		require_once( buddypress()->plugin_dir . 'bp-core/admin/bp-core-admin-tools.php' );
+	},
+) );

--- a/components/tool.php
+++ b/components/tool.php
@@ -45,35 +45,6 @@ class BPCLI_Tool extends BPCLI_Component {
 			WP_CLI::error( $result[1] );
 		}
 	}
-
-	/**
-	 * Reinstall BuddyPress default emails.
-	 *
-	 * ## OPTIONS
-	 *
-	 * [--yes]
-	 * : Answer yes to the confirmation message.
-	 *
-	 * ## EXAMPLE
-	 *
-	 *     $ wp bp tool reinstall_emails --yes
-	 *     Success: Emails have been successfully reinstalled.
-	 */
-	public function reinstall_emails( $args, $assoc_args ) {
-		WP_CLI::confirm( 'Are you sure you want to reinstall BuddyPress emails?', $assoc_args );
-
-		$result = bp_admin_reinstall_emails();
-
-		if ( 0 === $result[0] ) {
-			WP_CLI::success( $result[1] );
-		} else {
-			WP_CLI::error( $result[1] );
-		}
-	}
 }
 
-WP_CLI::add_command( 'bp tool', 'BPCLI_Tool', array(
-	'before_invoke' => function() {
-		require_once( buddypress()->plugin_dir . 'bp-core/admin/bp-core-admin-tools.php' );
-	},
-) );
+WP_CLI::add_command( 'bp tool', 'BPCLI_Tool' );

--- a/wp-cli-bp.php
+++ b/wp-cli-bp.php
@@ -21,4 +21,5 @@ WP_CLI::add_hook( 'before_wp_load', function() {
 	require_once( __DIR__ . '/components/xprofile-data.php' );
 	require_once( __DIR__ . '/components/tool.php' );
 	require_once( __DIR__ . '/components/message.php' );
+	require_once( __DIR__ . '/components/email.php' );
 } );


### PR DESCRIPTION
Needed to manage some aspects of how email posts are generated, so decided to write a BP CLI `email` command for it!

I've created the following sub-commands:

`wp bp email create` adds a new post connected to an email type.

Example:

`wp bp email create --type=new-event --type_description="Send an email when a new event is created" --subject="[{{{site.name}}}] A new event was created" --content="<a href='{{{some.custom-token-url}}}'></a>A new event</a> was created" --plain_text_content="A new event was created"`

----

`wp bp email get-post` grabs details about the email post for a given email type.

Works similar to `wp post get`.

Example:

`wp bp email get-post activity-at-message --fields=ID`

Will output the following:

```
+-------+-------+     
| Field | Value |     
+-------+-------+     
| ID    | X     |     
+-------+-------+ 
```

----

`wp bp email reinstall` is the same as the existing `wp bp tool reinstall_emails` subcommand.

----

I didn't write any behat tests as I don't have that set up yet on my rig.

Let me know what you think.