### PR TITLE
Improve PHP 5.3 compatibility

### DIFF
--- a/components/activity.php
+++ b/components/activity.php
@@ -899,7 +899,8 @@ class Activity extends BuddypressCommand {
 
 			case 'created_group':
 				if ( empty( $r['item-id'] ) ) {
-					$r['item-id'] = \BP_Groups_Group::get_random( 1, 1 )['groups'][0]->slug;
+					$random_group = \BP_Groups_Group::get_random( 1, 1 );
+					$r['item-id'] = $random_group['groups'][0]->slug;
 				}
 
 				$group = groups_get_group( array(
@@ -925,7 +926,8 @@ class Activity extends BuddypressCommand {
 
 			case 'joined_group':
 				if ( empty( $r['item-id'] ) ) {
-					$r['item-id'] = \BP_Groups_Group::get_random( 1, 1 )['groups'][0]->slug;
+					$random_group = \BP_Groups_Group::get_random( 1, 1 );
+					$r['item-id'] = $random_group['groups'][0]->slug;
 				}
 
 				$group = groups_get_group( array(

--- a/components/group-invite.php
+++ b/components/group-invite.php
@@ -233,9 +233,11 @@ class Group_Invite extends BuddypressCommand {
 		$notify = WP_CLI\Utils\make_progress_bar( 'Generating random group invitations', $assoc_args['count'] );
 
 		for ( $i = 0; $i < $assoc_args['count']; $i++ ) {
+
+			$random_group = \BP_Groups_Group::get_random( 1, 1 );
 			$this->add( array(), array(
 				'user-id'    => $this->get_random_user_id(),
-				'group-id'   => \BP_Groups_Group::get_random( 1, 1 )['groups'][0]->slug,
+				'group-id'   => $random_group['groups'][0]->slug,
 				'inviter-id' => $this->get_random_user_id(),
 				'silent',
 			) );


### PR DESCRIPTION
Cache result of call to \BP_Groups_Group::get_random() to avoid use of function array dereferencing, for compatibility with PHP 5.3 per https://buddypress.trac.wordpress.org/ticket/7838