### PR TITLE
When activating component, use `buddypress()->plugin_dir` to build sc…

### DIFF
--- a/components/component.php
+++ b/components/component.php
@@ -82,7 +82,7 @@ class Components extends BuddypressCommand {
 		}
 
 		// Run the setup, in case tables have to be created.
-		require_once( \BP_PLUGIN_DIR . 'bp-core/admin/bp-core-admin-schema.php' );
+		require_once( buddypress()->plugin_dir . 'bp-core/admin/bp-core-admin-schema.php' );
 		bp_core_install( $active_components );
 		bp_core_add_page_mappings( $active_components );
 


### PR DESCRIPTION
…hema file path.

This prevents errors when running a dev checkout of BuddyPress, where the
plugin is running from the /src/ directory.