### PR TITLE
Groups: Fix 'list' subcommand's 'count' associated argument

### DIFF
--- a/components/group.php
+++ b/components/group.php
@@ -375,10 +375,8 @@ class Group extends BuddypressCommand {
 			'show_hidden' => true,
 			'orderby'     => $assoc_args['orderby'],
 			'order'       => $assoc_args['order'],
+			'per_page'    => $assoc_args['count'],
 		) );
-
-		// Groups to list.
-		$r['per_page'] = $r['count'];
 
 		if ( isset( $assoc_args['user-id'] ) ) {
 			$user = $this->get_user_id_from_identifier( $assoc_args['user-id'] );


### PR DESCRIPTION
Came across this bug while using `wp bp group list --count=X`

The `$r` variable doesn't exist.  Probably a copypasta from some older code.