### PR TITLE
Member generate: Fix reference to WP_CLI User_Command class.

### DIFF
--- a/components/member.php
+++ b/components/member.php
@@ -1,7 +1,7 @@
 <?php
 namespace Buddypress\CLI\Command;
 
-if ( ! class_exists( 'User_Command' ) ) {
+if ( ! class_exists( '\User_Command' ) ) {
 	require_once( WP_CLI_ROOT . '/php/commands/user.php' );
 }
 
@@ -31,7 +31,8 @@ class Member extends BuddypressCommand {
 	 */
 	public function generate( $args, $assoc_args ) {
 		add_action( 'user_register', array( __CLASS__, 'update_user_last_activity_random' ) );
-		User_Command::generate( $args, $assoc_args );
+		$command_class = new \User_Command();
+		$command_class->generate( $args, $assoc_args );
 	}
 
 	/**


### PR DESCRIPTION
The namespacing was causing the `Member::generate()` function to refer to `Buddypress\CLI\Command\User_Command::generate()`, which is not where it is. :)