### PR TITLE
Activity Meta Commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 2.0.0
 
+* Abstracted activity ID fetching to the `Activity_Fetcher` helper class
 * The package was upgraded to follow WP-CLI best practices in code organization and structure
 * The `before_invoke` callable was abstracted into their component class
 * We made sure all Behat tests were passing correctly
@@ -18,7 +19,8 @@
 * Updated or removed the `default` values from several commands (most of them were wrong)
 * New commands:
 	* `wp bp group meta` - Used to manage Group Meta (custom fields).
-	* `wp bp tool signup 0` - Used to (de)activate the Signup feature.
+	* `wp bp activity meta` - Used to manage Activity Meta (custom fields).
+	* `wp bp tool signup false` - Used to (de)activate the Signup feature.
 
 ### 1.8.0
 

--- a/features/activity-meta.feature
+++ b/features/activity-meta.feature
@@ -1,0 +1,103 @@
+Feature: Manage BuddyPress Activity custom fields
+
+  Background:
+    Given a WP install
+    And these installed and active plugins:
+      """
+      https://github.com/buddypress/BuddyPress/archive/master.zip
+      """
+    And I run `wp bp component activate activity`
+
+  Scenario: Activity Meta CRUD
+
+    When I run `wp user create testuser2 testuser2@example.com --first_name=test --last_name=user --role=subscriber --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {MEMBER_ID}
+
+    When I run `wp bp activity create --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {ACTIVITY_ID}
+
+    When I run `wp bp activity meta add {ACTIVITY_ID} foo 'bar'`
+    Then STDOUT should not be empty
+
+    When I run `wp bp activity meta get {ACTIVITY_ID} foo`
+    Then STDOUT should be:
+      """
+      bar
+      """
+
+    When I try `wp bp activity meta get 999999 foo`
+    Then STDERR should be:
+      """
+      Error: Could not find the activity with ID 999999.
+      """
+    And the return code should be 1
+
+    When I run `wp bp activity meta set {ACTIVITY_ID} foo '[ "1", "2" ]' --format=json`
+    Then STDOUT should not be empty
+
+    When I run `wp bp activity meta get {ACTIVITY_ID} foo --format=json`
+    Then STDOUT should be:
+      """
+      ["1","2"]
+      """
+
+    When I run `wp bp activity meta delete {ACTIVITY_ID} foo`
+    Then STDOUT should not be empty
+
+    When I try `wp bp activity meta get {ACTIVITY_ID} foo`
+    Then the return code should be 1
+
+  Scenario: Add activity meta with JSON serialization
+
+    When I run `wp user create testuser2 testuser2@example.com --first_name=test --last_name=user --role=subscriber --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {MEMBER_ID}
+
+    When I run `wp bp activity create --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {ACTIVITY_ID}
+
+    When I run `wp bp activity meta add {ACTIVITY_ID} foo '"-- hi"' --format=json`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp bp activity meta get {ACTIVITY_ID} foo`
+    Then STDOUT should be:
+      """
+      -- hi
+      """
+
+  Scenario: List activity meta
+
+    When I run `wp user create testuser2 testuser2@example.com --first_name=test --last_name=user --role=subscriber --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {MEMBER_ID}
+
+    When I run `wp bp activity create --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {ACTIVITY_ID}
+
+    When I run `wp bp activity meta add {ACTIVITY_ID} apple banana`
+    And I run `wp bp activity meta add {ACTIVITY_ID} apple banana`
+    Then STDOUT should not be empty
+
+    When I run `wp bp activity meta set {ACTIVITY_ID} banana '["apple", "apple"]' --format=json`
+    Then STDOUT should not be empty
+
+    When I run `wp bp activity meta list {ACTIVITY_ID}`
+    Then STDOUT should be a table containing rows:
+      | activity_id | meta_key | meta_value                             |
+      | 1           | apple    | banana                                 |
+      | 1           | apple    | banana                                 |
+      | 1           | banana   | a:2:{i:0;s:5:"apple";i:1;s:5:"apple";} |
+
+    When I run `wp bp activity meta list 1 --unserialize`
+    Then STDOUT should be a table containing rows:
+      | activity_id | meta_key | meta_value        |
+      | 1           | apple    | banana            |
+      | 1           | apple    | banana            |
+      | 1           | banana   | ["apple","apple"] |

--- a/src/activity-fetcher.php
+++ b/src/activity-fetcher.php
@@ -6,6 +6,8 @@ use WP_CLI\Fetchers\Base;
 
 /**
  * Fetch a BuddyPress activity based on one of its attributes.
+ *
+ * @since 2.0.0
  */
 class Activity_Fetcher extends Base {
 
@@ -17,11 +19,11 @@ class Activity_Fetcher extends Base {
 	/**
 	 * Get an activity ID.
 	 *
-	 * @param int $arg Activity ID.
+	 * @param int $activity_id Activity ID.
 	 * @return BP_Activity_Activity|bool
 	 */
-	public function get( $arg ) {
-		$activity = new \BP_Activity_Activity( $arg );
+	public function get( $activity_id ) {
+		$activity = new \BP_Activity_Activity( $activity_id );
 
 		if ( empty( $activity->id ) ) {
 			return false;

--- a/src/activity-fetcher.php
+++ b/src/activity-fetcher.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Buddypress\CLI\Command;
+
+use WP_CLI\Fetchers\Base;
+
+/**
+ * Fetch a BuddyPress activity based on one of its attributes.
+ */
+class Activity_Fetcher extends Base {
+
+	/**
+	 * @var string $msg Error message to use when invalid data is provided.
+	 */
+	protected $msg = 'Could not find the activity with ID %d.';
+
+	/**
+	 * Get an activity ID.
+	 *
+	 * @param int $arg Activity ID.
+	 * @return BP_Activity_Activity|bool
+	 */
+	public function get( $arg ) {
+		$activity = new \BP_Activity_Activity( $arg );
+
+		if ( empty( $activity->id ) ) {
+			return false;
+		}
+
+		return $activity;
+	}
+}

--- a/src/activity-meta.php
+++ b/src/activity-meta.php
@@ -5,28 +5,28 @@ namespace Buddypress\CLI\Command;
 use WP_CLI\CommandWithMeta;
 
 /**
- * Adds, updates, deletes, and lists group custom fields.
+ * Adds, updates, deletes, and lists activity custom fields.
  *
  * ## EXAMPLES
  *
- *     # Set group meta
- *     $ wp bp group meta set 123 description "Mary is a Group user."
+ *     # Set activity meta
+ *     $ wp bp activity meta set 123 description "Mary is a activity user."
  *     Success: Updated custom field 'description'.
  *
- *     # Get group meta
- *     $ wp bp group meta get 123 description
- *     Mary is a Group user.
+ *     # Get activity meta
+ *     $ wp bp activity meta get 123 description
+ *     Mary is a Activity user.
  *
- *     # Update group meta
- *     $ wp bp group meta update 123 description "Mary is an awesome Group user."
+ *     # Update activity meta
+ *     $ wp bp activity meta update 123 description "Mary is an awesome activity user."
  *     Success: Updated custom field 'description'.
  *
- *     # Delete group meta
- *     $ wp bp group meta delete 123 description
+ *     # Delete activity meta
+ *     $ wp bp activity meta delete 123 description
  *     Success: Deleted custom field.
  */
-class Group_Meta extends CommandWithMeta {
-	protected $meta_type = 'group';
+class Activity_Meta extends CommandWithMeta {
+	protected $meta_type = 'activity';
 
 	/**
 	 * Wrapper method for add_metadata that can be overridden in sub classes.
@@ -44,7 +44,7 @@ class Group_Meta extends CommandWithMeta {
 	 * @return int|false The meta ID on success, false on failure.
 	 */
 	protected function add_metadata( $object_id, $meta_key, $meta_value, $unique = false ) {
-		return groups_add_groupmeta( $object_id, $meta_key, $meta_value );
+		return bp_activity_add_meta( $object_id, $meta_key, $meta_value );
 	}
 
 	/**
@@ -62,7 +62,7 @@ class Group_Meta extends CommandWithMeta {
 	 *                  update, false on failure.
 	 */
 	protected function update_metadata( $object_id, $meta_key, $meta_value, $prev_value = '' ) {
-		return groups_update_groupmeta( $object_id, $meta_key, $meta_value, $prev_value );
+		return bp_activity_update_meta( $object_id, $meta_key, $meta_value, $prev_value );
 	}
 
 	/**
@@ -79,7 +79,7 @@ class Group_Meta extends CommandWithMeta {
 	 * @return mixed Single metadata value, or array of values.
 	 */
 	protected function get_metadata( $object_id, $meta_key = '', $single = true ) {
-		return groups_get_groupmeta( $object_id, $meta_key, $single );
+		return bp_activity_get_meta( $object_id, $meta_key, $single );
 	}
 
 	/**
@@ -99,19 +99,19 @@ class Group_Meta extends CommandWithMeta {
 	 * @return bool True on successful delete, false on failure.
 	 */
 	protected function delete_metadata( $object_id, $meta_key, $meta_value = '' ) {
-		return groups_delete_groupmeta( $object_id, $meta_key, $meta_value );
+		return bp_activity_delete_meta( $object_id, $meta_key, $meta_value );
 	}
 
 	/**
-	 * Check that the group ID exists.
+	 * Check that the activity ID exists.
 	 *
 	 * @param int $object_id Object ID.
 	 * @return int
 	 */
 	protected function check_object_id( $object_id ) {
-		$fetcher = new Group_Fetcher();
-		$group   = $fetcher->get_check( $object_id );
+		$fetcher  = new Activity_Fetcher();
+		$activity = $fetcher->get_check( $object_id );
 
-		return $group->id;
+		return $activity->id;
 	}
 }

--- a/src/activity-meta.php
+++ b/src/activity-meta.php
@@ -24,6 +24,8 @@ use WP_CLI\CommandWithMeta;
  *     # Delete activity meta
  *     $ wp bp activity meta delete 123 description
  *     Success: Deleted custom field.
+ *
+ * @since 2.0.0
  */
 class Activity_Meta extends CommandWithMeta {
 	protected $meta_type = 'activity';

--- a/src/command.php
+++ b/src/command.php
@@ -44,6 +44,24 @@ abstract class BuddyPressCommand extends CommandWithDBObject {
 	}
 
 	/**
+	 * Get an activity ID.
+	 *
+	 * @param int  $activity_id Activity ID.
+	 * @param bool $object      Return activity object.
+	 * @return int|BP_Activity_Activity
+	 */
+	protected function get_activity_id_from_identifier( $activity_id, $object = false ) {
+		$fetcher  = new Activity_Fetcher();
+		$activity = $fetcher->get_check( $activity_id );
+
+		if ( true === $object ) {
+			return $activity;
+		}
+
+		return $activity->id;
+	}
+
+	/**
 	 * Get a group ID from its identifier (ID or slug).
 	 *
 	 * @since 1.5.0

--- a/src/command.php
+++ b/src/command.php
@@ -14,6 +14,8 @@ abstract class BuddyPressCommand extends CommandWithDBObject {
 
 	/**
 	 * Default dependency check for a BuddyPress CLI command.
+	 *
+	 * @since 2.0
 	 */
 	public static function check_dependencies() {
 		if ( ! class_exists( 'Buddypress' ) ) {
@@ -23,6 +25,8 @@ abstract class BuddyPressCommand extends CommandWithDBObject {
 
 	/**
 	 * Get Formatter object based on supplied parameters.
+	 *
+	 * @since 2.0
 	 *
 	 * @param array $assoc_args Parameters passed to command. Determines formatting.
 	 * @return \WP_CLI\Formatter
@@ -45,6 +49,8 @@ abstract class BuddyPressCommand extends CommandWithDBObject {
 
 	/**
 	 * Get an activity ID.
+	 *
+	 * @since 2.0
 	 *
 	 * @param int  $activity_id Activity ID.
 	 * @param bool $object      Return activity object.

--- a/src/group-meta.php
+++ b/src/group-meta.php
@@ -24,6 +24,8 @@ use WP_CLI\CommandWithMeta;
  *     # Delete group meta
  *     $ wp bp group meta delete 123 description
  *     Success: Deleted custom field.
+ *
+ * @since 2.0.0
  */
 class Group_Meta extends CommandWithMeta {
 	protected $meta_type = 'group';

--- a/src/group.php
+++ b/src/group.php
@@ -276,7 +276,7 @@ class Group extends BuddyPressCommand {
 	 * ## OPTIONS
 	 *
 	 * <group-id>...
-	 * : Identifier(s) for the group(s). Can be a numeric ID or the group slug.
+	 * : ID or IDs of group(s) to delete. Can be a numeric ID or the group slug.
 	 *
 	 * [--yes]
 	 * : Answer yes to the confirmation message.
@@ -293,7 +293,7 @@ class Group extends BuddyPressCommand {
 		WP_CLI::confirm( 'Are you sure you want to delete this group and its metadata?', $assoc_args );
 
 		parent::_delete( $args, $assoc_args, function( $group_id ) {
-			if ( groups_delete_group( (int) $group_id ) ) {
+			if ( groups_delete_group( $group_id ) ) {
 				return array( 'success', 'Group successfully deleted.' );
 			} else {
 				return array( 'error', 'Could not delete the group.' );

--- a/src/tool.php
+++ b/src/tool.php
@@ -94,6 +94,8 @@ class Tool extends BuddyPressCommand {
 	 *
 	 *     $ wp bp tool signup 0
 	 *     Success: Signup tool updated.
+	 *
+	 * @since 2.0.0
 	 */
 	public function signup( $args ) {
 		bp_update_option( 'users_can_register', $args[0] );

--- a/wp-cli-bp.php
+++ b/wp-cli-bp.php
@@ -13,8 +13,10 @@ WP_CLI::add_hook( 'before_wp_load', function() {
 	require_once( __DIR__ . '/src/command.php' );
 	require_once( __DIR__ . '/src/buddypress.php' );
 	require_once( __DIR__ . '/src/signup.php' );
+	require_once( __DIR__ . '/src/activity-fetcher.php' );
 	require_once( __DIR__ . '/src/activity.php' );
 	require_once( __DIR__ . '/src/activity-favorite.php' );
+	require_once( __DIR__ . '/src/activity-meta.php' );
 	require_once( __DIR__ . '/src/components.php' );
 	require_once( __DIR__ . '/src/tool.php' );
 	require_once( __DIR__ . '/src/notification.php' );
@@ -95,6 +97,12 @@ WP_CLI::add_hook( 'before_wp_load', function() {
 	WP_CLI::add_command(
 		'bp activity favorite',
 		__NAMESPACE__ . '\\Command\\Activity_Favorite',
+		array( 'before_invoke' => __NAMESPACE__ . '\\Command\\Activity::check_dependencies' )
+	);
+
+	WP_CLI::add_command(
+		'bp activity meta',
+		__NAMESPACE__ . '\\Command\\Activity_Meta',
 		array( 'before_invoke' => __NAMESPACE__ . '\\Command\\Activity::check_dependencies' )
 	);
 


### PR DESCRIPTION
Adding support to the BuddyPress Activity Meta commands:

```
$ wp bp activity meta
usage: wp bp activity meta add <id> <key> [<value>] [--format=<format>]
   or: wp bp activity meta delete <id> [<key>] [<value>] [--all]
   or: wp bp activity meta get <id> <key> [--format=<format>]
   or: wp bp activity meta list <id> [--keys=<keys>] [--fields=<fields>] [--format=<format>] [--orderby=<fields>] [--order=<order>]
   or: wp bp activity meta patch <action> <id> <key> <key-path>... [<value>] [--format=<format>]
   or: wp bp activity meta pluck <id> <key> <key-path>... [--format=<format>]
   or: wp bp activity meta update <id> <key> [<value>] [--format=<format>]
```

fixes #85 