### PR TITLE
Activity: Correct capitalization of `id` field in `list` command

### DIFF
--- a/src/activity.php
+++ b/src/activity.php
@@ -226,7 +226,7 @@ class Activity extends BuddyPressCommand {
 	 *
 	 * These fields will be displayed by default for each activity:
 	 *
-	 * * ID
+	 * * id
 	 * * user_id
 	 * * component
 	 * * type


### PR DESCRIPTION
`wp help bp activity list` shows the available fields with `ID` (capitalized), but using that results in an error:


```sh
> wp bp activity list --count=6 --type=wordcamp_organizer_add --fields=ID,user_id,component,type,action,date_recorded
Error: Invalid field: ID.
```

The field is actually named `id` (lowercase):

```sh
> wp bp activity list --count=6 --type=wordcamp_organizer_add --fields=id,user_id,component,type,action,date_recorded
+---------+----------+-----------+------------------------------+------------------------------+-----------------------------------+
| id      | user_id  | component | type                         | action                       | date_recorded                     |
+---------+----------+-----------+------------------------------+------------------------------+-----------------------------------+
...
```